### PR TITLE
Add help files for lcaSetTimeout and lcaSetRetryCount

### DIFF
--- a/documentation/Makefile
+++ b/documentation/Makefile
@@ -64,6 +64,15 @@ HELPS=$(patsubst %,help/%.html,$(HELP_AUTOGEN_CHAPTERS))
 
 MHELPS=$(HELPS:%.html=%.m)
 
+# Obtain the functions which share help documentation so we can generate .m files for both the getter and setter
+HELPS_SHARED_GET:=$(shell $(SED) -n -e 's/\(.*[^b]subsection.*[{][ \t]*\)\(lca[a-zA-Z0-9]*\)\(,\slca[a-zA-Z0-9]*\).*/\2/gp' manual.tex)
+
+HELPS_SHARED_SET:=$(shell $(SED) -n -e 's/\(.*[^b]subsection.*[{][ \t]*\)\(lca[a-zA-Z0-9]*\)\(,\s\)\(lca[a-zA-Z0-9]*\).*/\4/gp' manual.tex)
+
+MHELPS_COPY_FROM=$(patsubst %,help/%.m,$(HELPS_SHARED_GET))
+
+MHELPS_NEEDING_COPY=$(patsubst %,help/%.m,$(HELPS_SHARED_SET))
+
 ifneq '$(wildcard $(SCILAB))' ''
 SCI5HELPS=$(patsubst %,xmlhelp/en_US/%.xml,$(HELP_AUTOGEN_CHAPTERS))
 SCI5HELPS+=xmlhelp/en_US/Common.xml
@@ -149,6 +158,8 @@ help/Contents.m: Contents.m
 	$(RM) $@
 	cp $< $@
 
+$(MHELPS_NEEDING_COPY): $(MHELPS)
+	$(subst ^, ,$(join $(addprefix cp^,$(MHELPS_COPY_FROM)),$(patsubst %,^%;,$(MHELPS_NEEDING_COPY))))
 
 # html->text, add leading '%' and remove long URLs, just leave filename
 %.m:%.html
@@ -163,6 +174,7 @@ endif
 
 ifeq ($(HAVE_LYNX),YES)
 build: $(MHELPS) help/Contents.m
+build: $(MHELPS_NEEDING_COPY)
 endif
 
 # make again for the HTMLS wildcard expansion to find the newly created files


### PR DESCRIPTION
Hi! A user reported that when trying to pull up help for `lcaSetTimeout`, it did not work:

```
>> help lcaSetTmeout 
lcaSetTimeout is a MEX-file
```

It appears that a .m file is not generated for `lcaSetTimeout` and `lcaSetRetryCount` since they share the same documentation with their respective getters in the manual file.

I figure just copying the .m file from the getters into the setter versions would be easiest to fix this, as then no edits to the manual are needed at all. This attempts to keep things generic by grabbing those that need adding with `sed`. And just copies both whenever the target is executed so that `lcaSetRetryCount.m` and `lcaSetTimeout.m` will both exist now. (As well as anything similar that would be added in the future)

But since it's only 2 maybe would be fine and simpler to just have 2 targets, one for each file that just do the copy which I could do as well.

Or of course feel free to fix in a different way if you'd like!