### PR TITLE
Enable the ability to use lcaDebugOn and lcaDebugOff

### DIFF
--- a/documentation/Contents.m
+++ b/documentation/Contents.m
@@ -14,7 +14,7 @@
 %   lcaGetEnumStrings         - read the ENUM strings defined for a PV
 %   lcaGetRetryCount         - read/set the EZCA library retry count parameter
 %   lcaGetTimeout            - read/set the EZCA library timeout parameter
-%   lcaDebugOn               - NOT IMPLEMENTED YET (toggle EZCA library debugging messages on/off)
+%   lcaDebugOn               - toggle EZCA library debugging messages on/off
 %   lcaSetSeverityWarnLevel  - set the warning threshold used when reading EPICS 'VAL' PVs
 %   lcaClear                 - clear (destroy/cleanup) channels and associated monitors
 %   lcaSetMonitor            - monitor a channel

--- a/matlab/Makefile
+++ b/matlab/Makefile
@@ -48,6 +48,8 @@ MEXF += lcaNewMonitorValue
 MEXF += lcaNewMonitorWait
 MEXF += lcaDelay
 MEXF += lcaLastError
+MEXF += lcaDebugOn
+MEXF += lcaDebugOff
 ifeq ($(CONFIG_ECDRGET),YES)
 MEXF += ecget
 endif


### PR DESCRIPTION
Hi! A user was having trouble with a connection to an ioc and wanted to try enabling debugging to help, but couldn't:

```
>> lcaDebugOn
Unrecognized function or variable 'lcaDebugOn'.
```

I took a look and you have already added the wrappers around `ezcaDebugOn` and `ezcaDebugOff`, this PR just makes them available through `lcaDebugOn` and `lcaDebugOff`. 

I've tested both functions after applying this change and the debug output looks good to me. But if there's any reason for not enabling these functions let me know. Thanks!
