### PR TITLE
Unlock before calling ca_clear_event to prevent a deadlock

### DIFF
--- a/ezca/ezca.c
+++ b/ezca/ezca.c
@@ -5053,7 +5053,16 @@ int rval = 0;
 
 static int EzcaClearEvent(struct monitor *mp)
 {
-	return mp ? ca_clear_event(mp->evd) : ECA_NORMAL;
+    int rval = ECA_NORMAL;
+    if (mp) {
+        /* ca_clear_event() waits for the user's monitor callback to complete,
+         * we must unlock to prevent deadlock.
+         */
+        EZCA_UNLOCK();
+        rval = ca_clear_event(mp->evd);
+        EZCA_LOCK();
+    }
+    return rval;
 } /* end EzcaClearEvent() */
 
 /****************************************************************


### PR DESCRIPTION
Hi!

While setting up monitors on many PVs using `lcaSetMonitor`, a user noticed an issue where the application would often hang upon calling `lcaClear`. The problem was traced to the call to `ca_clear_event` in `EzcaClearEvent`, and appears to be due to the deadlock that happens when holding a mutex as noted here: https://epics.anl.gov/base/R3-14/12-docs/CAref.html#ca_clear_event (same for 3.15+ and 7)

This just changes it to unlock first, the same as is done for `EzcaClearChannel`. After doing this, the application no longer hangs.
